### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -7,3 +7,9 @@
  **/
 
 define('SS_SHARETHIS_DIR', 'sharethis');
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/api/MyTwitter.php
+++ b/code/api/MyTwitter.php
@@ -7,7 +7,7 @@
  *
  **/
 
-class MyTwitter extends Object
+class MyTwitter extends SS_Object
 {
     private static $debug = false;
 

--- a/code/api/SilverstripeFacebookConnector.php
+++ b/code/api/SilverstripeFacebookConnector.php
@@ -6,7 +6,7 @@
  *
  */
 
-class SilverstripeFacebookConnector extends Object
+class SilverstripeFacebookConnector extends SS_Object
 {
 
     /**

--- a/code/data/ShareThisOptions.php
+++ b/code/data/ShareThisOptions.php
@@ -4,7 +4,7 @@
  * @author nicolaas [at] sunnysideup.co.nz
  *
  */
-class ShareThisOptions extends Object
+class ShareThisOptions extends SS_Object
 {
     private static $page_specific_data;
 


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors).

If you don't mind, could you also make this a tagged release please so we avoid requiring the branch.