### PR TITLE
having fa-li class was to hard to override css, so it's easier to work

### DIFF
--- a/css/-SocialNetworking-Original.css
+++ b/css/-SocialNetworking-Original.css
@@ -6,42 +6,10 @@
 		.socialNetworkingHeader h5{text-align: right; display: none;}
 	.socialNetworkingList{}
 		.socialNetworkingList li{list-style :none!important;float: right;width: auto;}
-			.socialNetworkingList li a{padding:0 .1em; margin:0 0.5em; opacity:0.33; filter:alpha(opacity=33);}
+			.socialNetworkingList li a{padding: 0.1em;opacity:0.33; filter:alpha(opacity=33);}
 				.socialNetworkingList li a:hover{opacity:1;filter:alpha(opacity=100); text-decoration: none!important; border-bottom: none!important;}
 				.socialNetworkingList li a img{padding-right : 3px;}
 					.socialNetworkingList li a:hover img{margin-top: -1px; }
-
-
-
-
-
-
-
-
-
-/* With Font Awesome Horizontal Display Icons Only */
-.socialNetworkingHolder{float:right;}
-.socialNetworkingHeader {float:left;  margin-left: 1.5em; padding: 0.2em 0.75em;}
-.socialNetworkingHeader h5 {display:block; margin:0; padding:0; line-height:normal;}
-.socialNetworkingList {margin-left:auto!important; list-style-position: inside; float:right;}
-.socialNetworkingList li {list-style-type: none!important; padding:0;}
-.socialNetworkingList.fa-ul { }
-.socialNetworkingList.fa-ul li {padding:0; display:inline-block; }
-.socialNetworkingList.fa-ul li a {padding:0 0.15em; position:relative !important;}
-.socialNetworkingList.fa-ul li a .iconTitle { display:none;} 
-
-
-/* With Font Awesome Vertical Display Icons Only ===== Not Working yet ======= 
-.socialNetworkingHolder{float:right; clear:none; margin-left: 1.5em;}
-.socialNetworkingHeader {float:none; margin: 0 auto 0.75em auto; -ms-writing-mode: tb-lr; -webkit-writing-mode: vertical-lr; -moz-writing-mode: vertical-lr; -ms-writing-mode: vertical-lr; writing-mode: vertical-lr;}
-.socialNetworkingList.fa-ul li {padding:0.2em 0; display:block;}
-*/
-
-
-
-
-
-
 
 
 /*

--- a/templates/Includes/ShareThis.ss
+++ b/templates/Includes/ShareThis.ss
@@ -2,12 +2,12 @@
 
 <% if ShowShareIcons %><% if ShareIcons %>
 	<div class="ShareThisHolder socialNetworkingHolder">
-		<div class="ShareThisHeader socialNetworkingHeader typography"><h5>Share</h5></div>
+		<div class="ShareThisHeader socialNetworkingHeader typography"><h5>share this</h5></div>
 		<ul class="ShareThisUL socialNetworkingList fa-ul">
 			<% loop ShareIcons %>
 			<li class="icon-for{$Key} ">
-				<% if FAIcon %><i class="fa-li fa $FAIcon fa-3x"></i><% end_if %>
 				<a href="$URL" <% if OnClick %>onclick="$OnClick" <% end_if %>title="$Title.ATT">
+					<% if FAIcon %><i class="/*fa-li*/ fa $FAIcon fa-2x"></i><% end_if %>
 					<% if ImageSource %><img src="$ImageSource" alt="$Title"<% if UseStandardImage %> width="16" height="16"<% end_if %> /><% end_if %>
 					<span class="iconTitle">$Title</span>
 				</a>

--- a/templates/Includes/SocialNetworkingLinks.ss
+++ b/templates/Includes/SocialNetworkingLinks.ss
@@ -4,7 +4,7 @@
 	<div id="SocialNetworkingLinksHolder" class="socialNetworkingHolder">
 		<div id="SocialNetworkingLinksHeader" class="socialNetworkingHeader typography"><h5>follow</h5></div>
 		<ul id="SocialNetworkingLinksUL" class="socialNetworkingList">
-			<% loop SocialNetworks %><li class="$FirstLast $Code"><a href="$Link">$Icon.SetHeight(32) <span class="iconTitle">$Title</span></a></li><% end_loop %>
+			<% loop SocialNetworks %><li class="$FirstLast $Code"><a href="$Link"><% if FAIcon %><i class="fa-li fa $FAIcon fa-2x"></i><% end_if %> $Icon.SetHeight(32) <span class="iconTitle">$Title</span></a></li><% end_loop %>
 		</ul>
 	</div>
 <% end_if %><% end_if %>


### PR DESCRIPTION
with base classes fa $FAIcon fa-3x. Also moved <i> tag inside the <a> rollover would be more consistent with site css that way